### PR TITLE
Better handling of empty repositories

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -355,8 +355,9 @@ class Repositories(QObject):
             b.append("&amp; ")
             content = content.replace(a, b)
             reposXML.setContent(content)
-            pluginNodes = reposXML.elementsByTagName("pyqgis_plugin")
-            if pluginNodes.size():
+            plugins_tag = reposXML.elementsByTagName("plugins")
+            if plugins_tag.size():
+                pluginNodes = reposXML.elementsByTagName("pyqgis_plugin")
                 for i in range(pluginNodes.size()):
                     fileName = pluginNodes.item(i).firstChildElement("file_name").text().strip()
                     if not fileName:


### PR DESCRIPTION
At the moment QGIS shows an error message if on of the added plugin-repositories is empty.

If you use several repositories for testing new plugins or plugin-versions these repositories can be temporary empty, so there is just the <plugin>-tag:
```
<?xml version = "1.0" encoding = "UTF-8"?>
<plugins>
</plugins>

```
The changes in the installer_data.py allow handling of empty repositories.